### PR TITLE
Update hash() to await and return

### DIFF
--- a/src/monorepo-hash.ts
+++ b/src/monorepo-hash.ts
@@ -663,9 +663,11 @@ export async function hash(): Promise<void> {
   // 5) perform generate or compare
   if (mode === "generate") {
     await generateHashes(pkgs, finalCache)
+
     return
   } else {
     await compareHashes(pkgs, finalCache)
+
     return
   }
 }

--- a/src/monorepo-hash.ts
+++ b/src/monorepo-hash.ts
@@ -662,9 +662,11 @@ export async function hash(): Promise<void> {
 
   // 5) perform generate or compare
   if (mode === "generate") {
-    generateHashes(pkgs, finalCache)
+    await generateHashes(pkgs, finalCache)
+    return
   } else {
-    compareHashes(pkgs, finalCache)
+    await compareHashes(pkgs, finalCache)
+    return
   }
 }
 


### PR DESCRIPTION
## Summary
- await `generateHashes` or `compareHashes` inside `hash`
- exit early from `hash` after either call

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68476372d8a48325afc6d9fbc4814fdd