### PR TITLE
Cache package.json manifest during hash generation

### DIFF
--- a/src/monorepo-hash.ts
+++ b/src/monorepo-hash.ts
@@ -19,6 +19,7 @@ export interface PackageInfo {
   deps: string[]
   perFileHashes: Record<string, string>
   ownHash?: Buffer
+  manifest: Record<string, any>
 }
 
 // Parse CLI flags
@@ -619,7 +620,14 @@ export async function hash(): Promise<void> {
 
     return [
       pkgName,
-      { dir, relDir, deps: [], perFileHashes: perFileMap, ownHash: ownBuffer },
+      {
+        dir,
+        relDir,
+        deps: [],
+        perFileHashes: perFileMap,
+        ownHash: ownBuffer,
+        manifest: pkgData,
+      },
     ] as [string, PackageInfo]
   }))
 
@@ -633,9 +641,7 @@ export async function hash(): Promise<void> {
 
   // 3) resolve internal deps for all pkgs (even those not in targets, since they might be needed for recursive hashing)
   const depEntries = await Promise.all(Object.entries(pkgs).map(async ([ pkgName, info ]) => {
-    const pkgJsonPath = path.join(info.dir, "package.json")
-    const pkgText = await fs.readFile(pkgJsonPath, "utf8")
-    const manifest = JSON.parse(pkgText)
+    const manifest = info.manifest
     const allDeps = {
       ...manifest.dependencies,
       ...manifest.devDependencies,

--- a/src/monorepo-hash.ts
+++ b/src/monorepo-hash.ts
@@ -18,8 +18,8 @@ export interface PackageInfo {
   relDir: string
   deps: string[]
   perFileHashes: Record<string, string>
-  ownHash?: Buffer
   manifest: Record<string, any>
+  ownHash?: Buffer
 }
 
 // Parse CLI flags
@@ -625,8 +625,8 @@ export async function hash(): Promise<void> {
         relDir,
         deps: [],
         perFileHashes: perFileMap,
-        ownHash: ownBuffer,
         manifest: pkgData,
+        ownHash: ownBuffer,
       },
     ] as [string, PackageInfo]
   }))

--- a/src/monorepo-hash.ts
+++ b/src/monorepo-hash.ts
@@ -13,12 +13,23 @@ import { findUp } from "find-up"
 
 export type PnpmWorkspaceConfig = { packages?: string[] }
 
+export interface PackageManifest {
+  name: string
+  version?: string
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+  optionalDependencies?: Record<string, string>
+  scripts?: Record<string, string>
+  [key: string]: unknown
+}
+
 export interface PackageInfo {
   dir: string
   relDir: string
   deps: string[]
   perFileHashes: Record<string, string>
-  manifest: Record<string, any>
+  manifest: PackageManifest
   ownHash?: Buffer
 }
 
@@ -595,7 +606,7 @@ export async function hash(): Promise<void> {
     const dir = path.dirname(absJson)
     const relDir = path.relative(repoRoot, dir)
 
-    const pkgData = JSON.parse(await fs.readFile(absJson, "utf8"))
+    const pkgData = JSON.parse(await fs.readFile(absJson, "utf8")) as PackageManifest
     const pkgName: string = pkgData.name
 
     // Get file list after ignores


### PR DESCRIPTION
## Summary
- add `manifest` cache to `PackageInfo`
- store parsed package.json during hashing
- reuse cached manifest for dependency analysis

## Testing
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684763755a6883258d1d589070d666ee