### PR TITLE
Add support for multiple workspace managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,8 +358,7 @@ This is especially useful because when you generate hashes, the action will pick
 For the very first run, you might need to create a workflow which will only checkout and save the .hash files in a cache for future runs.
 
 ## :construction: Limitations
-- Only works with `PNPM` for now  
-  If you really need support for `Yarn` or `NPM`, feel free to open an issue or even submit a pull request !
+- Supports `PNPM`, `Yarn`, `NPM`, `Bun` and `Deno`
 - Bases the transitive dependency detection on the `workspace:` field in the `package.json` files
 - If you use another Version Control System than `git`, we can't ignore your files correctly for the hashes generation
 - Your EOL (End of Line) should be consistent across your monorepo's files and the different environments it's being used in. Since Docker containers and GitHub Actions runners are based on Linux, it's recommended to use `LF` as EOL.  

--- a/tests/workspace-detection.test.ts
+++ b/tests/workspace-detection.test.ts
@@ -1,0 +1,69 @@
+import path from "node:path"
+import os from "node:os"
+import { mkdirp, writeJson, writeFile, pathExists, mkdtemp } from "fs-extra"
+import { execa } from "execa"
+import { beforeAll, describe, expect, it } from "vitest"
+
+const cli = "node"
+let cliScript: string
+
+beforeAll(() => {
+  cliScript = path.join(globalThis.tmpRoot, "monorepo-hash.js")
+})
+
+describe("workspace detection", () => {
+  it("detects Yarn workspaces", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "yarn-ws-"))
+    await mkdirp(path.join(root, "packages", "a"))
+    await writeJson(path.join(root, "package.json"), { workspaces: [ "packages/*" ] }, { spaces: 2 })
+    await writeFile(path.join(root, "yarn.lock"), "")
+    await writeJson(path.join(root, "packages", "a", "package.json"), { name: "a", version: "0.0.0" }, { spaces: 2 })
+    await writeFile(path.join(root, "packages", "a", "index.js"), "console.log('a')\n")
+
+    const result = await execa(cli, [ cliScript, "--generate" ], { cwd: root, reject: false })
+
+    expect(result.exitCode).toBe(0)
+    expect(await pathExists(path.join(root, "packages", "a", ".hash"))).toBe(true)
+  })
+
+  it("detects NPM workspaces", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "npm-ws-"))
+    await mkdirp(path.join(root, "packages", "a"))
+    await writeJson(path.join(root, "package.json"), { workspaces: [ "packages/*" ] }, { spaces: 2 })
+    await writeFile(path.join(root, "package-lock.json"), "{}")
+    await writeJson(path.join(root, "packages", "a", "package.json"), { name: "a", version: "0.0.0" }, { spaces: 2 })
+    await writeFile(path.join(root, "packages", "a", "index.js"), "console.log('a')\n")
+
+    const result = await execa(cli, [ cliScript, "--generate" ], { cwd: root, reject: false })
+
+    expect(result.exitCode).toBe(0)
+    expect(await pathExists(path.join(root, "packages", "a", ".hash"))).toBe(true)
+  })
+
+  it("detects Bun workspaces", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "bun-ws-"))
+    await mkdirp(path.join(root, "packages", "a"))
+    await writeJson(path.join(root, "package.json"), { workspaces: [ "packages/*" ] }, { spaces: 2 })
+    await writeFile(path.join(root, "bun.lock"), "")
+    await writeJson(path.join(root, "packages", "a", "package.json"), { name: "a", version: "0.0.0" }, { spaces: 2 })
+    await writeFile(path.join(root, "packages", "a", "index.js"), "console.log('a')\n")
+
+    const result = await execa(cli, [ cliScript, "--generate" ], { cwd: root, reject: false })
+
+    expect(result.exitCode).toBe(0)
+    expect(await pathExists(path.join(root, "packages", "a", ".hash"))).toBe(true)
+  })
+
+  it("detects Deno workspaces", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "deno-ws-"))
+    await mkdirp(path.join(root, "packages", "a"))
+    await writeFile(path.join(root, "deno.json"), JSON.stringify({ workspace: [ "packages/*" ] }, null, 2))
+    await writeJson(path.join(root, "packages", "a", "package.json"), { name: "a", version: "0.0.0" }, { spaces: 2 })
+    await writeFile(path.join(root, "packages", "a", "index.js"), "console.log('a')\n")
+
+    const result = await execa(cli, [ cliScript, "--generate" ], { cwd: root, reject: false })
+
+    expect(result.exitCode).toBe(0)
+    expect(await pathExists(path.join(root, "packages", "a", ".hash"))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- support Yarn, NPM, Bun and Deno workspaces
- clarify CLI help message
- document supported package managers
- test workspace detection for all package managers

## Testing
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6867d6178cf48325a334d6651ea692ea