### PR TITLE
Add multi-PM workspace detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ You can install `monorepo-hash` globally, but it's best to add it as a dev depen
 ```bash
 pnpm add -D monorepo-hash
 ```
-> [!TIP]  
-> Make sure that the `packages` field in your `pnpm-workspace.yaml` file is set up correctly, as `monorepo-hash` will use it to find your workspaces. Globs are supported.  
+> [!TIP]
+> Make sure that your workspace configuration is set up correctly (`pnpm-workspace.yaml`, `package.json` workspaces or `deno.json` workspace) as `monorepo-hash` will use it to find your workspaces. Globs are supported.
 > `monorepo-hash` will also use the `workspace:` field in your `package.json` files to detect transitive dependencies.  
 > Finally, it will generate `.hash` files for each workspace that you would need to keep in your VCS in order for it to be efficient (ex : to be reused in your CI). If you don't like having extra files or you have hundred of packages, use the `--unified` mode to obtain a single root `.hash` file instead.
 
@@ -98,8 +98,9 @@ Don't forget to delete these files afterwards !
 - `1` : Changes detected in the hashes
 - `2` : Error with the arguments (either `--generate` or `--compare` is missing, or both were provided)
 - `3` : Unknown arguments provided
-- `4` : No workspaces found, either the `pnpm-workspace.yaml` file is missing or the `packages` field is not set up correctly
-- `5` : An unexpected error occurred, please open an issue with the logs
+- `4` : No workspaces found or unsupported package manager
+- `5` : Package manager forced with `--packagemanager` not present in the repo
+- `99` : An unexpected error occurred, please open an issue with the logs
 
 ## :test_tube: Examples
 ### Outputs

--- a/src/monorepo-hash.ts
+++ b/src/monorepo-hash.ts
@@ -50,6 +50,7 @@ let targets: string[] | null = null
 let silent = false
 let debug = false
 let unified = false
+let pmOption: string | null = null
 
 for (const arg of argv) {
   if (arg === "--generate" || arg === "-g") {
@@ -76,10 +77,13 @@ for (const arg of argv) {
     debug = true
   } else if (arg === "--unified" || arg === "-u") {
     unified = true
+  } else if (arg.startsWith("--packagemanager=") || arg.startsWith("-pm=")) {
+    const [, val] = arg.split("=")
+    pmOption = val
   } else if (arg === "--help" || arg === "-h") {
     console.log(`
 monorepo-hash by EDM115
-A simple script to generate or compare .hash files for pnpm workspaces
+A simple script to generate or compare .hash files for various package managers
 
 Arguments :
   --generate        (-g)  Generate or update .hash files for all workspaces
@@ -88,6 +92,7 @@ Arguments :
   --silent          (-s)  Suppress output messages
   --debug           (-d)  Enable debug mode (per-file hashes)
   --unified         (-u)  Use a single root .hash file instead of per-workspace files
+  --packagemanager  (-pm) Force the package manager (pnpm, npm, yarn, bun, deno)
   --help            (-h)  Show this help message
 `)
 
@@ -395,27 +400,125 @@ if (!mode) {
   }
 }
 
-// Load pnpm-workspace.yaml
-const wsYaml: string | undefined = await findUp("pnpm-workspace.yaml")
+type PackageManager = "pnpm" | "npm" | "yarn" | "bun" | "deno"
 
-if (!wsYaml || !(await exists(wsYaml))) {
-  console.error("❌ pnpm-workspace.yaml not found")
+async function detectPNPM(): Promise<{ pm: PackageManager; root: string; globs: string[] } | null> {
+  const wsYaml = await findUp("pnpm-workspace.yaml")
 
+  if (!wsYaml || !(await exists(wsYaml))) {
+    return null
+  }
+
+  const root = dirname(wsYaml)
+  const config = load(await readFile(wsYaml, "utf8")) as PnpmWorkspaceConfig
+  const globs: string[] = Array.isArray(config.packages) ? config.packages : []
+
+  if (globs.length === 0) {
+    return null
+  }
+
+  return { pm: "pnpm", root, globs }
+}
+
+async function detectDeno(): Promise<{ pm: PackageManager; root: string; globs: string[] } | null> {
+  const denoPath = await findUp("deno.json")
+
+  if (!denoPath || !(await exists(denoPath))) {
+    return null
+  }
+
+  const root = dirname(denoPath)
+  const config = JSON.parse(await readFile(denoPath, "utf8")) as { workspace?: string[] }
+  const globs: string[] = Array.isArray(config.workspace) ? config.workspace : []
+
+  if (globs.length === 0) {
+    return null
+  }
+
+  return { pm: "deno", root, globs }
+}
+
+async function detectPkgJson(): Promise<{ pm: PackageManager; root: string; globs: string[] } | null> {
+  const pkgPath = await findUp(async (dir) => {
+    const p = join(dir, "package.json")
+
+    if (await exists(p)) {
+      const data = JSON.parse(await readFile(p, "utf8")) as { workspaces?: unknown }
+
+      if (data.workspaces) {
+        return p
+      }
+    }
+
+    return undefined
+  })
+
+  if (!pkgPath) {
+    return null
+  }
+
+  const root = dirname(pkgPath)
+  const pkg = JSON.parse(await readFile(pkgPath, "utf8")) as { workspaces?: string[] | { packages?: string[] } }
+  let globs: string[] = []
+
+  if (Array.isArray(pkg.workspaces)) {
+    globs = pkg.workspaces
+  } else if (pkg.workspaces && Array.isArray((pkg.workspaces as { packages?: string[] }).packages)) {
+    globs = (pkg.workspaces as { packages?: string[] }).packages as string[]
+  }
+
+  if (globs.length === 0) {
+    return null
+  }
+
+  if (await exists(join(root, "bun.lock"))) {
+    return { pm: "bun", root, globs }
+  }
+
+  if (await exists(join(root, "yarn.lock"))) {
+    return { pm: "yarn", root, globs }
+  }
+
+  return { pm: "npm", root, globs }
+}
+
+async function autoDetect(): Promise<{ pm: PackageManager; root: string; globs: string[] } | null> {
+  return (await detectPNPM())
+    ?? (await detectDeno())
+    ?? (await detectPkgJson())
+}
+
+async function detectSpecified(pm: PackageManager): Promise<{ pm: PackageManager; root: string; globs: string[] } | null> {
+  if (pm === "pnpm") return detectPNPM()
+  if (pm === "deno") return detectDeno()
+  return detectPkgJson().then((res) => {
+    if (!res) return null
+    if (res.pm === pm) return res
+    return null
+  })
+}
+
+const detected = pmOption ? await detectSpecified(pmOption as PackageManager) : await autoDetect()
+
+if (!detected) {
+  if (pmOption) {
+    const auto = await autoDetect()
+
+    if (auto) {
+      console.error(`❌ ${pmOption} workspaces not found. Did you mean --packagemanager=${auto.pm}?`)
+    } else {
+      console.error("❌ Specified package manager not found and no supported package manager detected")
+    }
+    process.exit(5)
+  }
+
+  console.error("❌ No workspaces found or unsupported package manager")
   process.exit(4)
 }
 
-const repoRoot: string = dirname(wsYaml)
+const { pm: packageManager, root: repoRoot, globs: workspaceGlobs } = detected
 
-const wsConfig: PnpmWorkspaceConfig = load(await readFile(wsYaml, "utf8")) as PnpmWorkspaceConfig
-const workspaceGlobs: string[] = Array.isArray(wsConfig.packages)
-  ? wsConfig.packages
-  : []
-
-if (workspaceGlobs.length === 0) {
-  console.error("❌ No \"packages:\" entries in pnpm-workspace.yaml")
-
-  process.exit(4)
-}
+log(`ℹ️  Using ${packageManager} workspaces from ${repoRoot}\n`)
 
 // Compile root .gitignore
 let rootIgnore = ignore()
@@ -898,5 +1001,5 @@ try {
 } catch (err) {
   console.error("❌ Unexpected error :")
   console.error(err instanceof Error ? err.message : String(err))
-  process.exit(5)
+  process.exit(99)
 }

--- a/tests/exitCodes.test.ts
+++ b/tests/exitCodes.test.ts
@@ -47,7 +47,7 @@ describe("exit codes", () => {
     expect(result.exitCode).toBe(3)
   })
 
-  it("returns 4 when pnpm-workspace.yaml is missing", async () => {
+  it("returns 4 when no workspaces can be found", async () => {
     if (!globalThis.tmpRoot) {
       throw new Error("tmpRoot is not set")
     }
@@ -63,7 +63,13 @@ describe("exit codes", () => {
     await writeFile(workspaceFilePath, workspaceContent)
   })
 
-  it("returns 5 on unexpected error", async () => {
+  it("returns 5 when forcing a wrong package manager", async () => {
+    const result = await execa(cli, [ cliScript, "--generate", "--packagemanager=yarn" ], { cwd, reject: false })
+
+    expect(result.exitCode).toBe(5)
+  })
+
+  it("returns 99 on unexpected error", async () => {
     if (!globalThis.tmpRoot) {
       throw new Error("tmpRoot is not set")
     }
@@ -75,7 +81,7 @@ describe("exit codes", () => {
     await writeFile(packageJsonPath, "{ invalid json }")
     const result = await execa(cli, [ cliScript, "--generate" ], { cwd, reject: false })
 
-    expect(result.exitCode).toBe(5)
+    expect(result.exitCode).toBe(99)
 
     await writeFile(packageJsonPath, packageJsonContent)
   })

--- a/tests/workspaceDetection.test.ts
+++ b/tests/workspaceDetection.test.ts
@@ -1,0 +1,88 @@
+import path from "node:path"
+import os from "node:os"
+import { mkdirp, mkdtemp, writeFile, writeJson, remove } from "fs-extra"
+import { execa } from "execa"
+import { describe, it, expect, beforeAll, afterEach } from "vitest"
+
+const cli = "node"
+let cliScript: string
+let tmpRoot: string
+const created: string[] = []
+
+beforeAll(() => {
+  tmpRoot = globalThis.tmpRoot
+  cliScript = path.join(tmpRoot, "monorepo-hash.js")
+})
+
+afterEach(async () => {
+  for (const d of created.splice(0)) {
+    await remove(d)
+  }
+})
+
+async function setupDir(name: string): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), name))
+  created.push(dir)
+  return dir
+}
+
+async function runGenerate(cwd: string) {
+  return execa(cli, [ cliScript, "--generate" ], { cwd, reject: false })
+}
+
+describe("workspace detection", () => {
+  it("detects npm workspaces", async () => {
+    const dir = await setupDir("npm-")
+    await writeJson(path.join(dir, "package.json"), { workspaces: [ "packages/*" ] }, { spaces: 2 })
+    await writeFile(path.join(dir, "package-lock.json"), "")
+    const pkg = path.join(dir, "packages", "a")
+    await mkdirp(pkg)
+    await writeJson(path.join(pkg, "package.json"), { name: "a", version: "0.0.0" }, { spaces: 2 })
+    await writeFile(path.join(pkg, "index.js"), "")
+
+    const result = await runGenerate(dir)
+
+    expect(result.exitCode).toBe(0)
+  })
+
+  it("detects yarn workspaces", async () => {
+    const dir = await setupDir("yarn-")
+    await writeJson(path.join(dir, "package.json"), { workspaces: [ "packages/*" ] }, { spaces: 2 })
+    await writeFile(path.join(dir, "yarn.lock"), "")
+    const pkg = path.join(dir, "packages", "a")
+    await mkdirp(pkg)
+    await writeJson(path.join(pkg, "package.json"), { name: "a", version: "0.0.0" }, { spaces: 2 })
+    await writeFile(path.join(pkg, "index.js"), "")
+
+    const result = await runGenerate(dir)
+
+    expect(result.exitCode).toBe(0)
+  })
+
+  it("detects bun workspaces", async () => {
+    const dir = await setupDir("bun-")
+    await writeJson(path.join(dir, "package.json"), { workspaces: [ "packages/*" ] }, { spaces: 2 })
+    await writeFile(path.join(dir, "bun.lock"), "")
+    const pkg = path.join(dir, "packages", "a")
+    await mkdirp(pkg)
+    await writeJson(path.join(pkg, "package.json"), { name: "a", version: "0.0.0" }, { spaces: 2 })
+    await writeFile(path.join(pkg, "index.js"), "")
+
+    const result = await runGenerate(dir)
+
+    expect(result.exitCode).toBe(0)
+  })
+
+  it("detects deno workspaces", async () => {
+    const dir = await setupDir("deno-")
+    await writeJson(path.join(dir, "deno.json"), { workspace: [ "packages/add" ] }, { spaces: 2 })
+    const pkg = path.join(dir, "packages", "add")
+    await mkdirp(pkg)
+    await writeJson(path.join(pkg, "package.json"), { name: "add", version: "0.0.0" }, { spaces: 2 })
+    await writeFile(path.join(pkg, "index.ts"), "")
+
+    const result = await runGenerate(dir)
+
+    expect(result.exitCode).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- add `--packagemanager` CLI option
- detect pnpm, npm, yarn, bun and deno workspaces
- show which package manager is used and update exit codes
- document the new behaviour
- test workspace detection for all supported PMs

## Links ?
closes #5  
closes #12

------
https://chatgpt.com/codex/tasks/task_e_688aecde446c8325821a1de485a44a9b